### PR TITLE
Add gray image input support

### DIFF
--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -166,7 +166,14 @@ AprilTagDetectionArray TagDetector::detectTags (
     const sensor_msgs::CameraInfoConstPtr& camera_info) {
   // Convert image to AprilTag code's format
   cv::Mat gray_image;
-  cv::cvtColor(image->image, gray_image, CV_BGR2GRAY);
+  if (image->image.channels() == 1)
+  {
+    gray_image = image->image;
+  }
+  else
+  {
+    cv::cvtColor(image->image, gray_image, CV_BGR2GRAY);
+  }
   image_u8_t apriltag_image = { .width = gray_image.cols,
                                   .height = gray_image.rows,
                                   .stride = gray_image.cols,

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -72,8 +72,7 @@ void ContinuousDetector::imageCallback (
   // AprilTag 2 on the iamge
   try
   {
-    cv_image_ = cv_bridge::toCvCopy(image_rect,
-                                    sensor_msgs::image_encodings::BGR8);
+    cv_image_ = cv_bridge::toCvCopy(image_rect, image_rect->encoding);
   }
   catch (cv_bridge::Exception& e)
   {


### PR DESCRIPTION
Adds gray image support by simply not converting the image if it only has one channel.

Needed to make it work for e.g. infrared cameras