### PR TITLE
Edit #1 of apriltag_ros

### DIFF
--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -1,11 +1,11 @@
 # AprilTag 3 code parameters
 # Find descriptions in apriltag/include/apriltag.h:struct apriltag_detector
 #                      apriltag/include/apriltag.h:struct apriltag_family
-tag_family:        'tag36h11' # options: tag36h11, tag25h9, tag16h5, tagStandard41h12
+tag_family:        'tag36h11' # options: tag36h11, tag25h9, tag16h5
 tag_threads:       2          # default: 2
 tag_decimate:      1.0        # default: 1.0
 tag_blur:          0.0        # default: 0.0
 tag_refine_edges:  1          # default: 1
 tag_debug:         0          # default: 0
 # Other parameters
-publish_tf:        true       # default: false
+publish_tf:        true       # default: true

--- a/apriltag_ros/config/tags.yaml
+++ b/apriltag_ros/config/tags.yaml
@@ -19,6 +19,14 @@
 #   ]
 standalone_tags:
   [
+   {id: 0, size: 0.086},
+   {id: 1, size: 0.130},
+   {id: 2, size: 0.043},
+   {id: 3, size: 0.086},
+   {id: 4, size: 0.086},
+   {id: 5, size: 0.086},
+   {id: 6, size: 0.086},
+   {id: 7, size: 0.086},
   ]
 # ## Tag bundle definitions
 # ### Remarks

--- a/apriltag_ros/msg/AprilTagDetection.msg
+++ b/apriltag_ros/msg/AprilTagDetection.msg
@@ -12,3 +12,9 @@ float64[] size
 # homography is from at least the four corners of one member tag and at most the
 # four corners of all member tags.
 geometry_msgs/PoseWithCovarianceStamped pose
+int32[2] pix_tl
+int32[2] pix_tr
+int32[2] pix_br
+int32[2] pix_bl
+
+


### PR DESCRIPTION
Removal of homography use in pixel coordinate determination, Inclusion of intrinsic-independent corner pixel coordinates for tags in rostopic /tag_detections