### PR TITLE
Default 'Release' build, lazy processing, add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+language: generic # optional, just removes the language badge
+
+services:
+  - docker
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+git:
+  quiet: true # optional, silences the cloning of the target repository
+
+env:
+  global: # global settings for all jobs
+    - ROS_REPO=ros
+    - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
+  matrix: # each line is a job
+    - ROS_DISTRO="kinetic"
+    - ROS_DISTRO="melodic"
+    - ROS_DISTRO="noetic"
+
+# clone and run industrial_ci
+install:
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+script:
+  - .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,19 @@
 # For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 
 language: generic # optional, just removes the language badge
-
 services:
   - docker
-
 cache:
   directories:
     - $HOME/.ccache
-
 git:
   quiet: true # optional, silences the cloning of the target repository
-
 env:
-  global: # global settings for all jobs
-    - ROS_REPO=ros
+  global:
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
   matrix: # each line is a job
-    - ROS_DISTRO="kinetic"
     - ROS_DISTRO="melodic"
     - ROS_DISTRO="noetic"
-
-# clone and run industrial_ci
 install:
   - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:

--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -30,7 +30,13 @@ link_directories(${apriltag_LIBDIR})
 #  Release        : w/o debug symbols, w/ optimization
 #  RelWithDebInfo : w/ debug symbols, w/ optimization
 #  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
-# set(CMAKE_BUILD_TYPE Release)
+# We default to 'Release' if none was specified
+IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  MESSAGE(STATUS "Setting build type to 'Release' as none was specified.")
+  SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type" FORCE)
+  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Coverage" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+ENDIF()
+
 
 set(CMAKE_CXX_STANDARD 11)
 add_compile_options("-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -232,6 +232,8 @@ class TagDetector
 
   // Draw the detected tags' outlines and payload values on the image
   void drawDetections(cv_bridge::CvImagePtr image);
+
+  bool get_publish_tf() const { return publish_tf_; }
 };
 
 } // namespace apriltag_ros

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.h
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.h
@@ -55,7 +55,9 @@ namespace apriltag_ros
 class ContinuousDetector: public nodelet::Nodelet
 {
  public:
-   ContinuousDetector();
+  ContinuousDetector() = default;
+  ~ContinuousDetector() = default;
+
   void onInit();
 
   void imageCallback(const sensor_msgs::ImageConstPtr& image_rect,

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -68,6 +68,17 @@ void ContinuousDetector::imageCallback (
     const sensor_msgs::ImageConstPtr& image_rect,
     const sensor_msgs::CameraInfoConstPtr& camera_info)
 {
+  // Lazy updates:
+  // When there are no subscribers _and_ when tf is not published,
+  // skip detection.
+  if (tag_detections_publisher_.getNumSubscribers() == 0 &&
+      tag_detections_image_publisher_.getNumSubscribers() == 0 &&
+      !tag_detector_->get_publish_tf())
+  {
+    // ROS_INFO_STREAM("No subscribers and no tf publishing, skip processing.");
+    return;
+  }
+
   // Convert ROS's sensor_msgs::Image to cv_bridge::CvImagePtr in order to run
   // AprilTag 2 on the iamge
   try

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -37,11 +37,6 @@ PLUGINLIB_EXPORT_CLASS(apriltag_ros::ContinuousDetector, nodelet::Nodelet);
 
 namespace apriltag_ros
 {
-
-ContinuousDetector::ContinuousDetector ()
-{
-}
-
 void ContinuousDetector::onInit ()
 {
   ros::NodeHandle& nh = getNodeHandle();


### PR DESCRIPTION
This PR makes three changes:

1. Default `CMAKE_BUILD_TYPE` to `Release` if none was specified.
2. Use lazy processing in `ContinuousDetector`: Only runs tag detection if there are subscribers to the published topics or if `tf` transforms are published.
3. Adds CI using Industrial-CI on Travis