### PR TITLE
Added support for multiple camera

### DIFF
--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -13,7 +13,10 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
   std_msgs
-  tf
+  tf2_ros
+  tf2_eigen
+  tf2_geometry_msgs
+  tf2_sensor_msgs
 )
 
 find_package(Eigen3 REQUIRED)
@@ -82,7 +85,10 @@ catkin_package(
     roscpp
     sensor_msgs
     std_msgs
-    tf
+    tf2_ros
+    tf2_eigen
+    tf2_geometry_msgs
+    tf2_sensor_msgs
   DEPENDS
     OpenCV
     apriltag

--- a/apriltag_ros/config/cameras.yaml
+++ b/apriltag_ros/config/cameras.yaml
@@ -1,0 +1,13 @@
+camera_image:
+  [                                             #List of camera_image topics to be used.
+  "/vision/basler_camera_bow/throttled/rgb_image_rect",
+  "/vision/basler_camera_port/throttled/rgb_image_rect",
+  "/vision/basler_camera_star/throttled/rgb_image_rect"
+  ]
+
+camera_info:                                    #List of camera_info topics that go with the camera_image topics above.  Both topics are required.
+  [
+  "/vision/basler_camera_bow/throttled/camera_info",
+  "/vision/basler_camera_port/throttled/camera_info",
+  "/vision/basler_camera_star/throttled/camera_info"
+  ]

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -60,7 +60,18 @@
 #include <opencv2/core/core.hpp>
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/image_encodings.h>
-#include <tf/transform_broadcaster.h>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/message_filter.h>
+#include <tf2_eigen/tf2_eigen.h>
+
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_broadcaster.h>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
 
 #include <apriltag.h>
 
@@ -180,8 +191,12 @@ class TagDetector
   bool remove_duplicates_;
   bool run_quietly_;
   bool publish_tf_;
-  tf::TransformBroadcaster tf_pub_;
-  std::string camera_tf_frame_;
+  std::string camera_tf_frame_, common_frame_;
+
+  tf2_ros::TransformBroadcaster tfBroadcaster_;
+  tf2_ros::Buffer tfBuffer_;
+  tf2_ros::TransformListener tfListener_;
+  double wait_for_tf_delay_;
 
  public:
 

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -251,6 +251,31 @@ class TagDetector
   bool get_publish_tf() const { return publish_tf_; }
 };
 
+class Camera
+{
+  public:
+    Camera(ros::NodeHandle &node_handle, ros::NodeHandle &private_node_handle, const std::string &image_topic, const std::string &info_topic)
+    {
+      cameraImage_topic = image_topic;
+      cameraInfo_topic = info_topic;
+
+      cameraImage_sub = new message_filters::Subscriber<sensor_msgs::Image>(node_handle, cameraImage_topic, 10);
+      cameraInfo_sub = new message_filters::Subscriber<sensor_msgs::CameraInfo>(node_handle, cameraInfo_topic, 10);
+      cameraSync  = new message_filters::TimeSynchronizer<sensor_msgs::Image, sensor_msgs::CameraInfo>(*cameraImage_sub, *cameraInfo_sub, 10);
+
+      tag_detector = std::shared_ptr<TagDetector>(new TagDetector(private_node_handle));
+    }
+
+    std::string cameraImage_topic, cameraInfo_topic;
+
+    message_filters::Subscriber<sensor_msgs::Image>* cameraImage_sub;
+    message_filters::Subscriber<sensor_msgs::CameraInfo>* cameraInfo_sub;
+    message_filters::TimeSynchronizer<sensor_msgs::Image, sensor_msgs::CameraInfo> *cameraSync;
+    
+    cv_bridge::CvImagePtr cv_image;
+    std::shared_ptr<TagDetector> tag_detector;
+};
+
 } // namespace apriltag_ros
 
 #endif // APRILTAG_ROS_COMMON_FUNCTIONS_H

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.h
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.h
@@ -46,6 +46,7 @@
 #include "apriltag_ros/common_functions.h"
 
 #include <memory>
+#include <mutex>
 
 #include <nodelet/nodelet.h>
 
@@ -61,17 +62,27 @@ class ContinuousDetector: public nodelet::Nodelet
   void onInit();
 
   void imageCallback(const sensor_msgs::ImageConstPtr& image_rect,
-                     const sensor_msgs::CameraInfoConstPtr& camera_info);
+                     const sensor_msgs::CameraInfoConstPtr& camera_info, 
+                     int index);
+
+  void publishDetections(const ros::TimerEvent& event);
 
  private:
-  std::shared_ptr<TagDetector> tag_detector_;
   bool draw_tag_detections_image_;
-  cv_bridge::CvImagePtr cv_image_;
+  bool is_rectified_;
+  //cv_bridge::CvImagePtr cv_image_;
+
+  std::vector<Camera> camera_;
+  AprilTagDetectionArray tag_detection_array_;
 
   std::shared_ptr<image_transport::ImageTransport> it_;
-  image_transport::CameraSubscriber camera_image_subscriber_;
   image_transport::Publisher tag_detections_image_publisher_;
   ros::Publisher tag_detections_publisher_;
+    
+  ros::Timer pub_timer_;
+  double output_frequency_;
+
+  std::recursive_mutex mutex_;
 };
 
 } // namespace apriltag_ros

--- a/apriltag_ros/launch/continuous_detection.launch
+++ b/apriltag_ros/launch/continuous_detection.launch
@@ -1,20 +1,56 @@
 <launch>
-  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
-  <arg name="node_namespace" default="apriltag_ros_continuous_node" />
-  <arg name="camera_name" default="/camera_rect" />
-  <arg name="camera_frame" default="camera" />
-  <arg name="image_topic" default="image_rect" />
+  <arg name="namespace"                               default="vision"                     doc="parent namespace for nodes and topics"/>
+  <arg name="run_as_nodelet"                          default="true"                       doc="flag to quickly switch back and forth between running as node or nodelet"/>
+  <arg name="nodelet_namespace"                       default="vision"                     doc="namespace for nodelet manager"/>
+  <arg name="nodelet_manager"                         default="tag_nodelet_manager"        doc="name of nodelet manager"/>
+  <arg name="start_nodelet_manager"                   default="true"                      doc="flag to create nodelet manager, otherwise it is assumed to already exist"/>
 
-  <!-- Set parameters -->
-  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
-  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  <arg name="id"                                      default="basler_camera_front"        doc="id appended to node/nodelet names"/>
+  <arg name="camera_frame"                            default=""                           doc="overrides frame in detection messages, set to empty string to use frame in camera_info topic"/>  
+  <arg name="common_frame"                            default=""                           doc="use to transform all detections into a common frame, useful for multicamera setups"/>  
+  <arg name="is_rectified"                            default="true"                      doc="if false subscriber will use camera_info to rectify the image (using K and D matrixes), otherwise camera_info is only used to develop pinhole camera model (P matrix)"/>  
+  <arg name="publish_tag_detections_image"            default="false"/>
+
+  <arg name="launch_prefix"                           default=""/> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+
+  <!-- Start Nodelet Manager  -->
+  <node if="$(eval arg('start_nodelet_manager') and arg('run_as_nodelet'))" 
+    ns="$(arg nodelet_namespace)" name="$(arg nodelet_manager)" 
+    pkg="nodelet" type="nodelet" args="manager" output="screen"/>
   
-  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
-    <!-- Remap topics from those used in code to those on the ROS network -->
-    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
-    <remap from="camera_info" to="$(arg camera_name)/camera_info" />
+  <!-- Node -->
+  <group unless="$(arg run_as_nodelet)">
+    <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" 
+      ns="$(arg namespace)" name="$(arg id)_apriltag_node" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
 
-    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
-    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: false -->
-  </node>
+      <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml"/>
+      <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" />
+      <rosparam command="load" file="$(find apriltag_ros)/config/cameras.yaml"/>
+
+      <param name="camera_frame" value="$(arg camera_frame)" />
+      <param name="common_frame" value="$(arg common_frame)" />
+      <param name="is_rectified" value="$(arg is_rectified)" />
+      <param name="publish_tag_detections_image" value="$(arg publish_tag_detections_image)" />
+
+    </node>
+  </group>
+
+  <!-- Nodelet -->
+  <group if="$(arg run_as_nodelet)">
+    <node pkg="nodelet" type="nodelet" 
+      name="$(arg id)_apriltag_nodelet"
+      args="load apriltag_ros/ContinuousDetector /$(arg nodelet_namespace)/$(arg nodelet_manager)" output="screen">
+
+      <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml"/>
+      <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" />
+      <rosparam command="load" file="$(find apriltag_ros)/config/cameras.yaml"/>
+
+      <param name="camera_frame" value="$(arg camera_frame)" />
+      <param name="common_frame" value="$(arg common_frame)" />
+      <param name="is_rectified" value="$(arg is_rectified)" />
+      <param name="publish_tag_detections_image" value="$(arg publish_tag_detections_image)" />
+
+    </node>
+  </group>
+
 </launch>

--- a/apriltag_ros/package.xml
+++ b/apriltag_ros/package.xml
@@ -35,14 +35,16 @@
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
-  <build_depend>tf</build_depend>
   <build_depend>nodelet</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>libopencv-dev</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_eigen</build_depend>
+  <build_depend>tf2_sensor_msgs</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   
-  <run_depend>tf</run_depend>
   <run_depend>apriltag</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
@@ -56,6 +58,10 @@
   <run_depend>pluginlib</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>libopencv-dev</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_eigen</run_depend>
+  <run_depend>tf2_sensor_msgs</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />


### PR DESCRIPTION
I have RTABMAP setup on my robot using multiple cameras, but when I tried to incorporate apriltags, I ran into an issue where apriltag_ros can only subscribe to one camera, and rtabmap can only subscribe to one tag_detector.  Therefore, I modified the apriltag code to subscribe to a list of camera topics and publish all detections on the same topic.  The modified code runs each camera in its own thread with a mutex around the code that merges them into a single topic.

I am new to github and pull requests, let me know if I am doing something wrong, but I think this addition could help others.