### PR TITLE
Add configurable max_hamming_distance for the AprilTag Detector

### DIFF
--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -7,6 +7,6 @@ tag_decimate:      1.0        # default: 1.0
 tag_blur:          0.0        # default: 0.0
 tag_refine_edges:  1          # default: 1
 tag_debug:         0          # default: 0
-max_hamming_dist:  2          # default: 2
+max_hamming_dist:  2          # default: 2 (tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory)
 # Other parameters
 publish_tf:        true       # default: false

--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -7,5 +7,6 @@ tag_decimate:      1.0        # default: 1.0
 tag_blur:          0.0        # default: 0.0
 tag_refine_edges:  1          # default: 1
 tag_debug:         0          # default: 0
+max_hamming_dist:  2          # default: 2
 # Other parameters
 publish_tf:        true       # default: false

--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -7,6 +7,6 @@ tag_decimate:      1.0        # default: 1.0
 tag_blur:          0.0        # default: 0.0
 tag_refine_edges:  1          # default: 1
 tag_debug:         0          # default: 0
-max_hamming_dist:  2          # default: 2 (tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory)
+max_hamming_dist:  2          # default: 2 (Tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory. Choose the largest value possible.)
 # Other parameters
 publish_tf:        true       # default: false

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -168,6 +168,7 @@ class TagDetector
   double blur_;
   int refine_edges_;
   int debug_;
+  int max_hamming_distance_;
 
   // AprilTag 2 objects
   apriltag_family_t *tf_;

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -168,7 +168,9 @@ class TagDetector
   double blur_;
   int refine_edges_;
   int debug_;
-  int max_hamming_distance_;
+  int max_hamming_distance_ = 2;  // Tunable, but really, 2 is a good choice. Values of >=3
+                                  // consume prohibitively large amounts of memory, and otherwise
+                                  // you want the largest value possible.
 
   // AprilTag 2 objects
   apriltag_family_t *tf_;

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -52,6 +52,7 @@ TagDetector::TagDetector(ros::NodeHandle pnh) :
     blur_(getAprilTagOption<double>(pnh, "tag_blur", 0.0)),
     refine_edges_(getAprilTagOption<int>(pnh, "tag_refine_edges", 1)),
     debug_(getAprilTagOption<int>(pnh, "tag_debug", 0)),
+    max_hamming_distance_(getAprilTagOption<int>(pnh, "max_hamming_dist", 2)),
     publish_tf_(getAprilTagOption<bool>(pnh, "publish_tf", false))
 {
   // Parse standalone tag descriptions specified by user (stored on ROS
@@ -146,7 +147,7 @@ TagDetector::TagDetector(ros::NodeHandle pnh) :
 
   // Create the AprilTag 2 detector
   td_ = apriltag_detector_create();
-  apriltag_detector_add_family(td_, tf_);
+  apriltag_detector_add_family_bits(td_, tf_, max_hamming_distance_);
   td_->quad_decimate = (float)decimate_;
   td_->quad_sigma = (float)blur_;
   td_->nthreads = threads_;


### PR DESCRIPTION
Adds configurable max hamming distance bits for the AprilTag Detector.

Context:
1. Noticed high memory usage for the 52h13 family detector.
2. Noticed that apriltag_ros initiates the apriltag detector with max_hamming_distance value of 2 bits by default which is hardcoded in the apriltag library.
2. Noticed that reducing the max_hamming_distance bits from 2 to 1 brings down memory usage drastically.
3. Added configurable ros param to be able to configure this value.

I might have missed some documentation files which might need to be updated. Happy to take a look at those.