### PR TITLE
set the tag's parent frame to the camera optical frame

### DIFF
--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -184,7 +184,6 @@ class TagDetector
   bool run_quietly_;
   bool publish_tf_;
   tf::TransformBroadcaster tf_pub_;
-  std::string camera_tf_frame_;
 
  public:
 

--- a/apriltag_ros/launch/continuous_detection.launch
+++ b/apriltag_ros/launch/continuous_detection.launch
@@ -2,7 +2,6 @@
   <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
   <arg name="node_namespace" default="apriltag_ros_continuous_node" />
   <arg name="camera_name" default="/camera_rect" />
-  <arg name="camera_frame" default="camera" />
   <arg name="image_topic" default="image_rect" />
 
   <!-- Set parameters -->
@@ -14,7 +13,6 @@
     <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
     <remap from="camera_info" to="$(arg camera_name)/camera_info" />
 
-    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
     <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: false -->
   </node>
 </launch>

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -155,13 +155,6 @@ TagDetector::TagDetector(ros::NodeHandle pnh) :
   td_->refine_edges = refine_edges_;
 
   detections_ = NULL;
-
-  // Get tf frame name to use for the camera
-  if (!pnh.getParam("camera_frame", camera_tf_frame_))
-  {
-    ROS_WARN_STREAM("Camera frame not specified, using 'camera'");
-    camera_tf_frame_ = "camera";
-  }
 }
 
 // destructor
@@ -398,7 +391,7 @@ AprilTagDetectionArray TagDetector::detectTags (
       tf::poseStampedMsgToTF(pose, tag_transform);
       tf_pub_.sendTransform(tf::StampedTransform(tag_transform,
                                                  tag_transform.stamp_,
-                                                 camera_tf_frame_,
+                                                 image->header.frame_id,
                                                  detection_names[i]));
     }
   }


### PR DESCRIPTION
From the commit message:
```
The image header carries the 'frame_id' which is set by a camera driver to
the optical image frame. The pose of tags that are detected in an image are
therefore defined in this optical frame.
```

This makes the launchfile argument and node parameter `camera_frame` obsolete.

Fixes #100 .