### PR TITLE
fix bug in single_image_client

### DIFF
--- a/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
@@ -90,11 +90,11 @@ int main(int argc, char **argv)
   if (!getRosParameter(pnh, "cy", cy))
     return 1;
   // Intrinsic camera matrix for the raw (distorted) images
-  service.request.camera_info.K[0] = fx;
-  service.request.camera_info.K[2] = cx;
-  service.request.camera_info.K[4] = fy;
-  service.request.camera_info.K[5] = cy;
-  service.request.camera_info.K[8] = 1.0;
+  service.request.camera_info.P[0] = fx;
+  service.request.camera_info.P[2] = cx;
+  service.request.camera_info.P[5] = fy;
+  service.request.camera_info.P[6] = cy;
+  service.request.camera_info.P[10] = 1.0;
 
   // Call the service (detect tags in the image specified by the
   // image_load_path)

--- a/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
@@ -90,6 +90,11 @@ int main(int argc, char **argv)
   if (!getRosParameter(pnh, "cy", cy))
     return 1;
   // Intrinsic camera matrix for the raw (distorted) images
+  service.request.camera_info.K[0] = fx;
+  service.request.camera_info.K[2] = cx;
+  service.request.camera_info.K[4] = fy;
+  service.request.camera_info.K[5] = cy;
+  service.request.camera_info.K[8] = 1.0;
   service.request.camera_info.P[0] = fx;
   service.request.camera_info.P[2] = cx;
   service.request.camera_info.P[5] = fy;


### PR DESCRIPTION
This fixes the bug in the single image client.
The camera_info was using K matrix to convert the camera_info msg.
However, it uses P matrix in the upstream code, see: https://github.com/ros-perception/vision_opencv/blob/noetic/image_geometry/src/pinhole_camera_model.cpp#L322-L327
By convert the K matrix to the P matrix, the apritag_ros can finally detect the tag pose. Otherwise, it will return a [0, 0, 0] pose instead.