### PR TITLE
Add transport options

### DIFF
--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -10,3 +10,4 @@ tag_debug:         0          # default: 0
 max_hamming_dist:  2          # default: 2 (Tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory. Choose the largest value possible.)
 # Other parameters
 publish_tf:        true       # default: false
+transport_hint:    "raw"      # default: raw, see http://wiki.ros.org/image_transport#Known_Transport_Packages for options

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -48,9 +48,13 @@ void ContinuousDetector::onInit ()
   it_ = std::shared_ptr<image_transport::ImageTransport>(
       new image_transport::ImageTransport(nh));
 
+  std::string transport_hint;
+  pnh.param<std::string>("transport_hint", transport_hint, "raw");
+
   camera_image_subscriber_ =
       it_->subscribeCamera("image_rect", 1,
-                          &ContinuousDetector::imageCallback, this);
+                          &ContinuousDetector::imageCallback, this,
+                          image_transport::TransportHints(transport_hint));
   tag_detections_publisher_ =
       nh.advertise<AprilTagDetectionArray>("tag_detections", 1);
   if (draw_tag_detections_image_)


### PR DESCRIPTION
In service of Issue #107, this pull request adds a parameter for `transport_hint` (defaults to `raw`) that is used when subscribing to the Camera. This enables users to switch to other forms of transport (e.g., "compressed").