### PR TITLE
Fixed propagation of apriltag and Eigen headers and libraries.

### DIFF
--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -65,8 +65,14 @@ generate_messages(
   std_msgs
 )
 
+# Extract the include directories and libraries from apriltag::apriltag as catkin_package() does not support modern cmake.
+get_target_property(apriltag_INCLUDE_DIRS apriltag::apriltag INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(apriltag_LIBRARIES apriltag::apriltag INTERFACE_LINK_LIBRARIES)
+
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS
+    include
+    ${EIGEN3_INCLUDE_DIRS}
   CATKIN_DEPENDS
     cv_bridge
     geometry_msgs
@@ -80,6 +86,7 @@ catkin_package(
     tf
   DEPENDS
     OpenCV
+    apriltag
   LIBRARIES
     ${PROJECT_NAME}_common
     ${PROJECT_NAME}_continuous_detector


### PR DESCRIPTION
When compiling our library which depends on `apriltag_ros` we have got the following error:

```
.../catkin_ws/install/include/apriltag_ros/common_functions.h:65:10: fatal error: apriltag.h: No such file or directory
   65 | #include <apriltag.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

I think that the `apriltag::apriltag` target is not propagated correctly.

As catkin does not support modern CMake targets like these, in this MR I suggest a workaround, extracting the "good old" `apriltag_INCLUDE_DIRS` and `apriltag_LIBRARIES` and propagate them using the `Depends` keyword.

Additionally, I fixed the Eigen headers not being properly forwarded either.