### PR TITLE
Distance limit

### DIFF
--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -11,3 +11,4 @@ max_hamming_dist:  2          # default: 2 (Tunable parameter with 2 being a goo
 # Other parameters
 publish_tf:        true       # default: false
 transport_hint:    "raw"      # default: raw, see http://wiki.ros.org/image_transport#Known_Transport_Packages for options
+detection_distance: 1.0 

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -163,6 +163,7 @@ class TagDetector
 
   // AprilTag 2 code's attributes
   std::string family_;
+  double detection_distance_;
   int threads_;
   double decimate_;
   double blur_;

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -16,7 +16,7 @@
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
  * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
  * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * CbONSEQUETIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
  * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
  * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -53,7 +53,8 @@ TagDetector::TagDetector(ros::NodeHandle pnh) :
     refine_edges_(getAprilTagOption<int>(pnh, "tag_refine_edges", 1)),
     debug_(getAprilTagOption<int>(pnh, "tag_debug", 0)),
     max_hamming_distance_(getAprilTagOption<int>(pnh, "max_hamming_dist", 2)),
-    publish_tf_(getAprilTagOption<bool>(pnh, "publish_tf", false))
+    publish_tf_(getAprilTagOption<bool>(pnh, "publish_tf", false)),
+    detection_distance_(getAprilTagOption<double>(pnh,"detection_distance",1.0))
 {
   // Parse standalone tag descriptions specified by user (stored on ROS
   // parameter server)
@@ -343,8 +344,8 @@ AprilTagDetectionArray TagDetector::detectTags (
     tag_detection.pose = tag_pose;
     tag_detection.id.push_back(detection->id);
     tag_detection.size.push_back(tag_size);
-    // This pr chooses the distance limit to push detection array, default selection 1.4 meter.
-    if (tag_detection.pose.pose.pose.position.z < 1.4)
+    // This pr chooses the distance limit to push detection array, default selection 1.0 meter.
+    if (tag_detection.pose.pose.pose.position.z < detection_distance_)
     tag_detection_array.detections.push_back(tag_detection);
     detection_names.push_back(standaloneDescription->frame_name());
   }

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -343,6 +343,8 @@ AprilTagDetectionArray TagDetector::detectTags (
     tag_detection.pose = tag_pose;
     tag_detection.id.push_back(detection->id);
     tag_detection.size.push_back(tag_size);
+    // This pr chooses the distance limit to push detection array, default selection 1.4 meter.
+    if (tag_detection.pose.pose.pose.position.z < 1.4)
     tag_detection_array.detections.push_back(tag_detection);
     detection_names.push_back(standaloneDescription->frame_name());
   }


### PR DESCRIPTION
To limit the detection of april tags into ros side I have added if statement taking the distance from ros (pose.pose.pose.position.z) and limit this distance related to tag type.
**EDIT**: I will provide param  distance values related to apriltag dimensions in launch file.
**_TODO_**
[distance-size rates](https://www.laserscanning-europe.com/en/what-apriltags-what-apriltag-size-should-use)
[parameter addition - I](https://github.com/tugbakara/apriltag_ros/blob/distance-limit-pr/apriltag_ros/src/common_functions.cpp#L48)
[parameter addition - II](https://github.com/tugbakara/apriltag_ros/blob/distance-limit-pr/apriltag_ros/src/common_functions.cpp#L83)
[parameter addition - III](https://github.com/tugbakara/apriltag_ros/blob/distance-limit-pr/apriltag_ros/launch/continuous_detection.launch#L9)