### PR TITLE
fixed bug into function TagDetector::idComparison.

### DIFF
--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -405,7 +405,7 @@ AprilTagDetectionArray TagDetector::detectTags (
 int TagDetector::idComparison (const void* first, const void* second)
 {
   int id1 = (*(apriltag_detection_t**)first)->id;
-  int id2 = (*(apriltag_detection_t**)first)->id;
+  int id2 = (*(apriltag_detection_t**)second)->id;
   return (id1 < id2) ? -1 : ((id1 == id2) ? 0 : 1);
 }
 

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -404,8 +404,8 @@ AprilTagDetectionArray TagDetector::detectTags (
 
 int TagDetector::idComparison (const void* first, const void* second)
 {
-  int id1 = ((apriltag_detection_t*) first)->id;
-  int id2 = ((apriltag_detection_t*) second)->id;
+  int id1 = (*(apriltag_detection_t**)first)->id;
+  int id2 = (*(apriltag_detection_t**)first)->id;
   return (id1 < id2) ? -1 : ((id1 == id2) ? 0 : 1);
 }
 


### PR DESCRIPTION
Previously it was assigning to id1 and id2 the addresses of the variable the two pointers were pointing to. 
Now, the real tag ID of the readings are correctly assigned to the two variables id1 and id2.