### PR TITLE
Fix memory leak in removeDuplicates

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -13,12 +13,12 @@ jobs:
       PRERELEASE: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # This step will fetch/store the directory used by ccache before/after the ci run
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       # Run industrial_ci
-      - uses: 'ros-industrial/industrial_ci@master'
+      - uses: 'ros-industrial/industrial_ci@6a8f546cbd31fbd5c9f77e3409265c8b39abc3d6'
         env: ${{ matrix.env }}

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -419,22 +419,23 @@ void TagDetector::removeDuplicates ()
       // The entire detection set was parsed
       return;
     }
-    apriltag_detection_t *detection;
-    zarray_get(detections_, count, &detection);
-    int id_current = detection->id;
+    apriltag_detection_t *next_detection, *current_detection;
+    zarray_get(detections_, count, &current_detection);
+    int id_current = current_detection->id;
     // Default id_next value of -1 ensures that if the last detection
     // is a duplicated tag ID, it will get removed
     int id_next = -1;
     if (count < zarray_size(detections_)-1)
     {
-      zarray_get(detections_, count+1, &detection);
-      id_next = detection->id;
+      zarray_get(detections_, count+1, &next_detection);
+      id_next = next_detection->id;
     }
     if (id_current == id_next || (id_current != id_next && duplicate_detected))
     {
       duplicate_detected = true;
       // Remove the current tag detection from detections array
       int shuffle = 0;
+      apriltag_detection_destroy(current_detection);
       zarray_remove_index(detections_, count, shuffle);
       if (id_current != id_next)
       {


### PR DESCRIPTION
We found a memory leak in removeDuplicates, elements were being removed from a zarray without being destroyed first.