### PR TITLE
Refresh Params Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/matlab_rosbag-0.5.0-linux64/
 **/*.bag
 .vscode/
+build/

--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -34,7 +34,7 @@ IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 ENDIF()
 
 
-add_compile_options("-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")
+add_compile_options("-std=c++17" "-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")
 
 # Note: These options have been turned off to allow for binary releases - 
 # in local builds, they can be reactivated to achieve higher performance.

--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(apriltag_ros)
 
+set(CMAKE_CXX_STANDARD 17)
+
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   cv_bridge
@@ -33,8 +35,7 @@ IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Coverage" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 ENDIF()
 
-
-add_compile_options("-std=c++17" "-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")
+add_compile_options("-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")
 
 # Note: These options have been turned off to allow for binary releases - 
 # in local builds, they can be reactivated to achieve higher performance.

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.h
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.h
@@ -46,8 +46,11 @@
 #include "apriltag_ros/common_functions.h"
 
 #include <memory>
+#include <mutex>
 
 #include <nodelet/nodelet.h>
+#include <ros/service_server.h>
+#include <std_srvs/Empty.h>
 
 namespace apriltag_ros
 {

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.h
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.h
@@ -63,7 +63,10 @@ class ContinuousDetector: public nodelet::Nodelet
   void imageCallback(const sensor_msgs::ImageConstPtr& image_rect,
                      const sensor_msgs::CameraInfoConstPtr& camera_info);
 
+  void refreshTagParameters();
+
  private:
+  std::mutex detection_mutex_;
   std::shared_ptr<TagDetector> tag_detector_;
   bool draw_tag_detections_image_;
   cv_bridge::CvImagePtr cv_image_;
@@ -72,6 +75,9 @@ class ContinuousDetector: public nodelet::Nodelet
   image_transport::CameraSubscriber camera_image_subscriber_;
   image_transport::Publisher tag_detections_image_publisher_;
   ros::Publisher tag_detections_publisher_;
+
+  ros::ServiceServer refresh_params_service_;
+  bool refreshParamsCallback(std_srvs::Empty::Request& req, std_srvs::Empty::Response& res);
 };
 
 } // namespace apriltag_ros

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -63,12 +63,35 @@ void ContinuousDetector::onInit ()
   {
     tag_detections_image_publisher_ = it_->advertise("tag_detections_image", 1);
   }
+
+  refresh_params_service_ =
+      pnh.advertiseService("refresh_tag_params", 
+                          &ContinuousDetector::refreshParamsCallback, this);
+}
+
+void ContinuousDetector::refreshTagParameters()
+{
+  // Reseting the tag detector will cause a new param server lookup
+  // So if the parameters have changed (by someone/somehting), 
+  // they will be updated dynamically
+  std::scoped_lock<std::mutex> lock(detection_mutex_);
+  ros::NodeHandle& pnh = getPrivateNodeHandle();
+  tag_detector_.reset();
+  tag_detector_ = std::shared_ptr<TagDetector>(new TagDetector(pnh));
+}
+
+bool ContinuousDetector::refreshParamsCallback(std_srvs::Empty::Request& req,
+                                               std_srvs::Empty::Response& res)
+{
+  refreshTagParameters();
+  return true;
 }
 
 void ContinuousDetector::imageCallback (
     const sensor_msgs::ImageConstPtr& image_rect,
     const sensor_msgs::CameraInfoConstPtr& camera_info)
 {
+  std::scoped_lock<std::mutex> lock(detection_mutex_);
   // Lazy updates:
   // When there are no subscribers _and_ when tf is not published,
   // skip detection.

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -71,13 +71,12 @@ void ContinuousDetector::onInit ()
 
 void ContinuousDetector::refreshTagParameters()
 {
-  // Reseting the tag detector will cause a new param server lookup
-  // So if the parameters have changed (by someone/somehting), 
+  // Resetting the tag detector will cause a new param server lookup
+  // So if the parameters have changed (by someone/something), 
   // they will be updated dynamically
   std::scoped_lock<std::mutex> lock(detection_mutex_);
   ros::NodeHandle& pnh = getPrivateNodeHandle();
-  tag_detector_.reset();
-  tag_detector_ = std::shared_ptr<TagDetector>(new TagDetector(pnh));
+  tag_detector_.reset(new TagDetector(pnh));
 }
 
 bool ContinuousDetector::refreshParamsCallback(std_srvs::Empty::Request& req,


### PR DESCRIPTION
Added a service `~/refresh_tag_params` that when called, resets the `TagDetector` which in turn looks up the parameters from the parameter server. If those params have since changed (manually or by some other piece of software) this will dynamically update the parameters used by the `ContinuousDetector`.