### PR TITLE
reduce cpu usage and tune params

### DIFF
--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -2,12 +2,12 @@
 # Find descriptions in apriltag/include/apriltag.h:struct apriltag_detector
 #                      apriltag/include/apriltag.h:struct apriltag_family
 tag_family:        'tag36h11' # options: tagStandard52h13, tagStandard41h12, tag36h11, tag25h9, tag16h5, tagCustom48h12, tagCircle21h7, tagCircle49h12
-tag_threads:       2          # default: 2
-tag_decimate:      1.0        # default: 1.0
+tag_threads:       1          # default: 2
+tag_decimate:      3.0        # default: 1.0
 tag_blur:          0.0        # default: 0.0
 tag_refine_edges:  1          # default: 1
 tag_debug:         0          # default: 0
 max_hamming_dist:  2          # default: 2 (Tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory. Choose the largest value possible.)
 # Other parameters
-publish_tf:        true       # default: false
+publish_tf:        false       # default: false
 transport_hint:    "raw"      # default: raw, see http://wiki.ros.org/image_transport#Known_Transport_Packages for options

--- a/apriltag_ros/config/tags.yaml
+++ b/apriltag_ros/config/tags.yaml
@@ -21,6 +21,10 @@
 #   ]
 standalone_tags:
   [
+    {id: 1, size: 0.16},
+    {id: 2, size: 0.16},
+    {id: 3, size: 0.16},
+    {id: 4, size: 0.16},
   ]
 # ## Tag bundle definitions
 # ### Remarks
@@ -45,4 +49,13 @@ standalone_tags:
 #   ]
 tag_bundles:
   [
+    {
+      name: 'triple_horizontal',
+      layout:
+        [
+          {id: 25, size: 0.16, x: 0, y: 0, z: 0, qw: 1, qx: 0, qy: 0, qz: 0},
+          {id: 26, size: 0.16, x: 0.2, y: 0, z: 0, qw: 1, qx: 0, qy: 0, qz: 0},
+          {id: 27, size: 0.16, x: -0.2, y: 0, z: 0, qw: 1, qx: 0, qy: 0, qz: 0},
+        ]
+    },
   ]

--- a/apriltag_ros/src/apriltag_ros_continuous_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_continuous_node.cpp
@@ -30,12 +30,14 @@
  */
 
 #include <ros/ros.h>
-
+#include <opencv2/opencv.hpp>
 #include <nodelet/loader.h>
 
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "apriltag_ros");
+  // Disable opencv threading optimizations
+  cv::setNumThreads(0);
 
   nodelet::Loader nodelet;
   nodelet::M_string remap(ros::names::getRemappings());


### PR DESCRIPTION
- Tune some params in settings.yaml to reduce cpu usage
- Disable opencv multithreading to greatly reduce cpu usage
- Add some sample tags to test the apriltag 3 detector