### PR TITLE
Tag Bundle Calibration Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.bag
 .vscode/
 build/
+.clang-format

--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   std_msgs
   tf
+  tf2
+  tf2_geometry_msgs
 )
 
 find_package(Eigen3 REQUIRED)
@@ -85,6 +87,8 @@ catkin_package(
     sensor_msgs
     std_msgs
     tf
+    tf2
+    tf2_geometry_msgs
   DEPENDS
     apriltag
     OpenCV
@@ -108,6 +112,9 @@ add_library(${PROJECT_NAME}_common src/common_functions.cpp)
 add_dependencies(${PROJECT_NAME}_common ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(${PROJECT_NAME}_common ${catkin_LIBRARIES} ${OpenCV_LIBRARIES} apriltag::apriltag)
 
+add_library(${PROJECT_NAME}_tag_bundle_calibration src/tag_bundle_calibration.cpp)
+target_link_libraries(${PROJECT_NAME}_tag_bundle_calibration ${PROJECT_NAME}_common ${catkin_LIBRARIES})
+
 add_library(${PROJECT_NAME}_continuous_detector src/continuous_detector.cpp)
 target_link_libraries(${PROJECT_NAME}_continuous_detector ${PROJECT_NAME}_common ${catkin_LIBRARIES})
 
@@ -125,6 +132,10 @@ target_link_libraries(${PROJECT_NAME}_single_image_server_node ${PROJECT_NAME}_s
 add_executable(${PROJECT_NAME}_single_image_client_node src/${PROJECT_NAME}_single_image_client_node.cpp)
 add_dependencies(${PROJECT_NAME}_single_image_client_node ${PROJECT_NAME}_generate_messages_cpp)
 target_link_libraries(${PROJECT_NAME}_single_image_client_node ${PROJECT_NAME}_common ${catkin_LIBRARIES})
+
+add_executable(${PROJECT_NAME}_tag_bundle_calibration_node src/${PROJECT_NAME}_tag_bundle_calibration_node.cpp)
+add_dependencies(${PROJECT_NAME}_tag_bundle_calibration_node ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(${PROJECT_NAME}_tag_bundle_calibration_node ${PROJECT_NAME}_tag_bundle_calibration ${catkin_LIBRARIES})
 
 
 #############
@@ -145,6 +156,7 @@ install(FILES nodelet_plugins.xml
 
 install(TARGETS
   ${PROJECT_NAME}_common
+  ${PROJECT_NAME}_tag_bundle_calibration
   ${PROJECT_NAME}_continuous_detector
   ${PROJECT_NAME}_continuous_node
   ${PROJECT_NAME}_single_image_client_node

--- a/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
+++ b/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
@@ -32,7 +32,7 @@ private:
   void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
                    const std::unordered_map<int, double>& tag_size_map,
                    const std::string& tag_bundle_name,
-                   std::ostream& os);
+                   std::ostream& os) const;
 
   ros::Subscriber tag_detection_sub_;
   int max_detections_;

--- a/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
+++ b/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
@@ -37,8 +37,7 @@ void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_i
 class TagBundleCalibrationNode
 {
 public:
-  TagBundleCalibrationNode(ros::NodeHandle& nh,
-                           int max_detections,
+  TagBundleCalibrationNode(int max_detections,
                            const std::string& config_file_path,
                            const std::string& tag_bundle_name,
                            int master_tag_id);

--- a/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
+++ b/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
@@ -18,16 +18,6 @@
 
 namespace apriltag_ros
 {
-namespace detail
-{
-
-geometry_msgs::Pose averagePoses(const std::vector<geometry_msgs::Pose>& poses);
-void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
-                 const std::unordered_map<int, double>& tag_size_map,
-                 const std::string& tag_bundle_name,
-                 std::ostream& os);
-} // namespace detail
-
 class TagBundleCalibrationNode
 {
 public:
@@ -38,6 +28,11 @@ public:
 
 private:
   void tagDetectionCallback(const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg);
+
+  void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
+                   const std::unordered_map<int, double>& tag_size_map,
+                   const std::string& tag_bundle_name,
+                   std::ostream& os);
 
   ros::Subscriber tag_detection_sub_;
   int max_detections_;

--- a/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
+++ b/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
@@ -18,12 +18,6 @@
 
 namespace apriltag_ros
 {
-void generateTagBundleConfig(
-    std::ostream& os,
-    const std::unordered_map<int, std::vector<AprilTagDetection>>& tag_buffer_map,
-    const std::string tag_bundle_name,
-    const int master_tag_id);
-
 namespace detail
 {
 
@@ -42,10 +36,8 @@ public:
                            const std::string& tag_bundle_name,
                            int master_tag_id);
 
-  void tagDetectionCallback(const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg);
-
 private:
-  void performCalibrationAndWriteToFile();
+  void tagDetectionCallback(const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg);
 
   ros::Subscriber tag_detection_sub_;
   int max_detections_;
@@ -53,7 +45,8 @@ private:
   std::string tag_bundle_name_;
   int master_tag_id_;
   int received_detections_;
-  std::unordered_map<int, std::vector<apriltag_ros::AprilTagDetection>> tag_buffer_map_;
+  std::unordered_map<int, geometry_msgs::Pose> tags_in_master_frame_;
+  std::unordered_map<int, double> tag_size_map_;
 };
 
 } // namespace apriltag_ros

--- a/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
+++ b/apriltag_ros/include/apriltag_ros/tag_bundle_calibration.h
@@ -1,0 +1,62 @@
+#ifndef APRILTAG_ROS_TAG_BUNDLE_CALIBRATION_H
+#define APRILTAG_ROS_TAG_BUNDLE_CALIBRATION_H
+
+#include <apriltag_ros/AprilTagDetection.h>
+#include <apriltag_ros/AprilTagDetectionArray.h>
+
+#include <geometry_msgs/Pose.h>
+#include <ros/ros.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <unordered_map>
+#include <vector>
+
+namespace apriltag_ros
+{
+void generateTagBundleConfig(
+    std::ostream& os,
+    const std::unordered_map<int, std::vector<AprilTagDetection>>& tag_buffer_map,
+    const std::string tag_bundle_name,
+    const int master_tag_id);
+
+namespace detail
+{
+
+geometry_msgs::Pose averagePoses(const std::vector<geometry_msgs::Pose>& poses);
+void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
+                 const std::unordered_map<int, double>& tag_size_map,
+                 const std::string& tag_bundle_name,
+                 std::ostream& os);
+} // namespace detail
+
+class TagBundleCalibrationNode
+{
+public:
+  TagBundleCalibrationNode(ros::NodeHandle& nh,
+                           int max_detections,
+                           const std::string& config_file_path,
+                           const std::string& tag_bundle_name,
+                           int master_tag_id);
+
+  void tagDetectionCallback(const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg);
+
+private:
+  void performCalibrationAndWriteToFile();
+
+  ros::Subscriber tag_detection_sub_;
+  int max_detections_;
+  std::string config_file_path_;
+  std::string tag_bundle_name_;
+  int master_tag_id_;
+  int received_detections_;
+  std::unordered_map<int, std::vector<apriltag_ros::AprilTagDetection>> tag_buffer_map_;
+};
+
+} // namespace apriltag_ros
+
+#endif // APRILTAG_ROS_TAG_BUNDLE_CALIBRATION_H

--- a/apriltag_ros/launch/tag_bundle_calibration.launch
+++ b/apriltag_ros/launch/tag_bundle_calibration.launch
@@ -1,0 +1,15 @@
+<launch>    
+    <arg name="tag_detection_topic" default="/tag_detections"/>
+    <arg name="max_detections" default="500"/>
+    <arg name="config_file_path" default="/tmp/tag_bundle_calibration.yaml"/>
+    <arg name="tag_bundle_name" default="tag_bundle"/>
+    <arg name="master_tag_id" default="0"/>
+
+    <node pkg="apriltag_ros" type="apriltag_ros_tag_bundle_calibration_node" name="apriltag_ros_tag_bundle_calibration_node" output="screen">
+        <remap from="~tag_detections" to="$(arg tag_detection_topic)"/>
+        <param name="max_detections" value="$(arg max_detections)"/>
+        <param name="config_file_path" value="$(arg config_file_path)"/>
+        <param name="tag_bundle_name" value="$(arg tag_bundle_name)"/>
+        <param name="master_tag_id" value="$(arg master_tag_id)"/>
+    </node>
+</launch>

--- a/apriltag_ros/package.xml
+++ b/apriltag_ros/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>apriltag_ros</name>
   <version>3.2.1</version>
   <description>
@@ -26,37 +26,25 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>apriltag</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>image_geometry</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>nodelet</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>eigen</build_depend>
-  <build_depend>libopencv-dev</build_depend>
-  <build_depend>cmake_modules</build_depend>
+  <depend>apriltag</depend>
+  <depend>geometry_msgs</depend>
+  <depend>image_transport</depend>
+  <depend>image_geometry</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>message_generation</depend>
+  <depend>message_runtime</depend>
+  <depend>std_msgs</depend>
+  <depend>cv_bridge</depend>
+  <depend>tf</depend>
+  <depend>nodelet</depend>
+  <depend>pluginlib</depend>
+  <depend>eigen</depend>
+  <depend>libopencv-dev</depend>
+  <depend>cmake_modules</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   
-  <run_depend>tf</run_depend>
-  <run_depend>apriltag</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>image_geometry</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>eigen</run_depend>
-  <run_depend>libopencv-dev</run_depend>
-
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>

--- a/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
 
   // Create the node
   apriltag_ros::TagBundleCalibrationNode node(
-      nh, max_detections, config_file_path, tag_bundle_name, master_tag_id);
+      max_detections, config_file_path, tag_bundle_name, master_tag_id);
 
   ros::spin();
   return 0;

--- a/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
@@ -5,7 +5,7 @@ int main(int argc, char** argv)
 {
   // Initialize the node and create a NodeHandle
   ros::init(argc, argv, "tag_bundle_calibration_node");
-  ros::NodeHandle nh;
+  ros::NodeHandle nh{"~"};
 
   // Read the parameters
   int max_detections;

--- a/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
@@ -1,0 +1,26 @@
+#include "apriltag_ros/tag_bundle_calibration.h"
+#include <ros/ros.h>
+
+int main(int argc, char** argv)
+{
+  // Initialize the node and create a NodeHandle
+  ros::init(argc, argv, "tag_bundle_calibration_node");
+  ros::NodeHandle nh;
+
+  // Read the parameters
+  int max_detections;
+  std::string config_file_path;
+  std::string tag_bundle_name;
+  int master_tag_id;
+  nh.param("max_detections", max_detections, 500);
+  nh.param("config_file_path", config_file_path, std::string("/tmp/tag_bundle_config.yaml"));
+  nh.param("tag_bundle_name", tag_bundle_name, std::string("tag_bundle"));
+  nh.param("master_tag_id", master_tag_id, 0);
+
+  // Create the node
+  apriltag_ros::TagBundleCalibrationNode node(
+      nh, max_detections, config_file_path, tag_bundle_name, master_tag_id);
+
+  ros::spin();
+  return 0;
+}

--- a/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_tag_bundle_calibration_node.cpp
@@ -3,11 +3,10 @@
 
 int main(int argc, char** argv)
 {
-  // Initialize the node and create a NodeHandle
   ros::init(argc, argv, "tag_bundle_calibration_node");
   ros::NodeHandle nh{"~"};
 
-  // Read the parameters
+  // Read params
   int max_detections;
   std::string config_file_path;
   std::string tag_bundle_name;
@@ -17,7 +16,6 @@ int main(int argc, char** argv)
   nh.param("tag_bundle_name", tag_bundle_name, std::string("tag_bundle"));
   nh.param("master_tag_id", master_tag_id, 0);
 
-  // Create the node
   apriltag_ros::TagBundleCalibrationNode node(
       max_detections, config_file_path, tag_bundle_name, master_tag_id);
 

--- a/apriltag_ros/src/tag_bundle_calibration.cpp
+++ b/apriltag_ros/src/tag_bundle_calibration.cpp
@@ -27,6 +27,7 @@ TagBundleCalibrationNode::TagBundleCalibrationNode(int max_detections,
 void TagBundleCalibrationNode::tagDetectionCallback(
     const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg)
 {
+  ROS_INFO_ONCE("Processing tag detections...");
   std::unordered_map<int, geometry_msgs::Pose> curr_tag_poses_in_cam_frame;
 
   for (const auto& tag_detection : msg->detections)
@@ -109,7 +110,7 @@ void TagBundleCalibrationNode::writeToYaml(
     const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
     const std::unordered_map<int, double>& tag_size_map,
     const std::string& tag_bundle_name,
-    std::ostream& os)
+    std::ostream& os) const
 {
   // Create a vector of constant references to the elements in tag_poses_in_master_frame
   std::vector<std::reference_wrapper<const std::pair<const int, geometry_msgs::Pose>>> sorted_tags(

--- a/apriltag_ros/src/tag_bundle_calibration.cpp
+++ b/apriltag_ros/src/tag_bundle_calibration.cpp
@@ -2,68 +2,6 @@
 
 namespace apriltag_ros
 {
-void generateTagBundleConfig(
-    std::ostream& os,
-    const std::unordered_map<int, std::vector<AprilTagDetection>>& tag_buffer_map,
-    const std::string tag_bundle_name,
-    const int master_tag_id)
-{
-  if (tag_buffer_map.find(master_tag_id) == tag_buffer_map.end())
-  {
-    throw std::runtime_error("Master tag ID has not been observed");
-  }
-
-  // Calculating the average pose for each tag
-  std::unordered_map<int, geometry_msgs::Pose> average_pose_map;
-  std::unordered_map<int, double> tag_size_map;
-  for (const auto& [tag_id, detections] : tag_buffer_map)
-  {
-    // Extracting the poses from the detections
-    std::vector<geometry_msgs::Pose> poses;
-    poses.reserve(detections.size());
-    for (const auto& detection : detections)
-    {
-      // Ignore tag bundle detections in the tag bundle calibration routine
-      if (detection.id.size() > 1)
-        continue;
-      poses.push_back(detection.pose.pose.pose);
-    }
-
-    // Averaging the poses
-    average_pose_map[tag_id] = detail::averagePoses(poses);
-    tag_size_map[tag_id] = detections[0].size[0];
-  }
-
-  // Get the master tag's pose
-  const geometry_msgs::Pose& master_pose = average_pose_map[master_tag_id];
-
-  // Convert the master pose to a tf2::Transform
-  tf2::Transform master_tf;
-  tf2::fromMsg(master_pose, master_tf);
-
-  // Compute the tag poses in the frame of the master tag
-  std::unordered_map<int, geometry_msgs::Pose> tag_poses_in_master_frame;
-  tag_poses_in_master_frame[master_tag_id] = geometry_msgs::Pose();
-  for (const auto& [tag_id, pose] : average_pose_map)
-  {
-    if (tag_id == master_tag_id)
-      continue;
-
-    // Convert the tag pose to a tf2::Transform
-    tf2::Transform tag_tf;
-    tf2::fromMsg(pose, tag_tf);
-
-    // Calculate the transform from the master tag to the current tag
-    tf2::Transform transform_in_master_frame = master_tf.inverse() * tag_tf;
-
-    // Convert the transform back to a geometry_msgs::Pose and store it
-    tag_poses_in_master_frame[tag_id] = geometry_msgs::Pose();
-    tf2::toMsg(transform_in_master_frame, tag_poses_in_master_frame[tag_id]);
-  }
-
-  // Pass the tag map and the output stream to the writeToYaml function
-  detail::writeToYaml(tag_poses_in_master_frame, tag_size_map, tag_bundle_name, os);
-}
 
 namespace detail
 {
@@ -121,6 +59,15 @@ void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_i
                  const std::string& tag_bundle_name,
                  std::ostream& os)
 {
+  // Create a vector of constant references to the elements in tag_poses_in_master_frame
+  std::vector<std::reference_wrapper<const std::pair<const int, geometry_msgs::Pose>>> sorted_tags(
+      tag_poses_in_master_frame.begin(), tag_poses_in_master_frame.end());
+
+  // Sort the vector by ascending tag ID
+  std::sort(sorted_tags.begin(),
+            sorted_tags.end(),
+            [](const auto& a, const auto& b) { return a.get().first < b.get().first; });
+
   os << "standalone_tags:\n";
   os << "  [\n";
   os << "  ]\n";
@@ -131,8 +78,11 @@ void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_i
   os << "      layout:\n";
   os << "        [\n";
 
-  for (const auto& [tag_id, pose] : tag_poses_in_master_frame)
+  for (const auto& tag_entry_ref : sorted_tags)
   {
+    const auto& tag_entry = tag_entry_ref.get();
+    int tag_id = tag_entry.first;
+    const geometry_msgs::Pose& pose = tag_entry.second;
     double size = tag_size_map.at(tag_id);
     os << "          {id: " << tag_id << ", size: " << size << ", x: " << pose.position.x
        << ", y: " << pose.position.y << ", z: " << pose.position.z << ", qw: " << pose.orientation.w
@@ -159,21 +109,79 @@ TagBundleCalibrationNode::TagBundleCalibrationNode(int max_detections,
     received_detections_(0)
 {
   ros::NodeHandle pnh{"~"};
-  tag_detection_sub_ =
-      pnh.subscribe("tag_detections", 1, &TagBundleCalibrationNode::tagDetectionCallback, this);
+  size_t q_size = max_detections_ + 1; // Should allow faster than real-time stuff w rosbags
+  tag_detection_sub_ = pnh.subscribe(
+      "tag_detections", q_size, &TagBundleCalibrationNode::tagDetectionCallback, this);
+
+  ROS_INFO_STREAM("Initialized tag bundle calibration node with the following parameters:\n"
+                  << "  max_detections: " << max_detections_ << "\n"
+                  << "  config_file_path: " << config_file_path_ << "\n"
+                  << "  tag_bundle_name: " << tag_bundle_name_ << "\n"
+                  << "  master_tag_id: " << master_tag_id_ << "\n");
 }
 
 void TagBundleCalibrationNode::tagDetectionCallback(
     const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg)
 {
-  for (const auto& detection : msg->detections)
+  std::unordered_map<int, geometry_msgs::Pose> curr_tag_poses_in_cam_frame;
+
+  for (const auto& tag_detection : msg->detections)
   {
-    // Only standalone tags
-    if (detection.id.size() == 1)
+    int tag_id = tag_detection.id[0];
+    double tag_size = tag_detection.size[0];
+    geometry_msgs::Pose tag_pose_in_master_frame = tag_detection.pose.pose.pose;
+
+    curr_tag_poses_in_cam_frame[tag_id] = tag_pose_in_master_frame;
+    // Build up the tag size map
+    if (tag_size_map_.find(tag_id) == tag_size_map_.end())
+      tag_size_map_[tag_id] = tag_size;
+  }
+
+  // If the master tag is not detected, skip this detection
+  if (curr_tag_poses_in_cam_frame.find(master_tag_id_) == curr_tag_poses_in_cam_frame.end())
+    return;
+
+  // Transform all tag poses to the master tag frame
+  geometry_msgs::Pose master_tag_pose = curr_tag_poses_in_cam_frame[master_tag_id_];
+  tf2::Transform master_tag_tf;
+  tf2::fromMsg(master_tag_pose, master_tag_tf);
+
+  // init the master tag pose if it is not already in the map
+  if (tags_in_master_frame_.find(master_tag_id_) == tags_in_master_frame_.end())
+    tags_in_master_frame_[master_tag_id_] = geometry_msgs::Pose{};
+
+  for (auto& tag_pose_kv : curr_tag_poses_in_cam_frame)
+  {
+    if (tag_pose_kv.first == master_tag_id_)
+      continue;
+
+    tf2::Transform tag_tf;
+    tf2::fromMsg(tag_pose_kv.second, tag_tf);
+
+    tf2::Transform relative_tf = master_tag_tf.inverse() * tag_tf;
+    geometry_msgs::Pose relative_pose;
+    tf2::toMsg(relative_tf, relative_pose);
+
+    int tag_id = tag_pose_kv.first;
+    // If this tag is not in tags_in_master_frame_, add it.
+    if (tags_in_master_frame_.find(tag_id) == tags_in_master_frame_.end())
     {
-      if (tag_buffer_map_.find(detection.id[0]) == tag_buffer_map_.end())
-        tag_buffer_map_[detection.id[0]] = {};
-      tag_buffer_map_[detection.id[0]].push_back(detection);
+      tags_in_master_frame_[tag_id] = relative_pose;
+    }
+    else
+    {
+      // Average the current pose with the previously stored pose.
+      geometry_msgs::Pose& prev_pose = tags_in_master_frame_[tag_id];
+
+      prev_pose.position.x = (prev_pose.position.x + relative_pose.position.x) / 2;
+      prev_pose.position.y = (prev_pose.position.y + relative_pose.position.y) / 2;
+      prev_pose.position.z = (prev_pose.position.z + relative_pose.position.z) / 2;
+
+      tf2::Quaternion prev_quat, relative_quat;
+      tf2::fromMsg(prev_pose.orientation, prev_quat);
+      tf2::fromMsg(relative_pose.orientation, relative_quat);
+      prev_quat = prev_quat.slerp(relative_quat, 0.5);
+      prev_pose.orientation = tf2::toMsg(prev_quat);
     }
   }
 
@@ -181,14 +189,16 @@ void TagBundleCalibrationNode::tagDetectionCallback(
 
   if (received_detections_ >= max_detections_)
   {
-    performCalibrationAndWriteToFile();
+    std::ofstream ofs{config_file_path_};
+    if (!ofs.is_open())
+    {
+      ROS_ERROR_STREAM("Failed to open file: " << config_file_path_);
+      ros::shutdown();
+      return;
+    }
+    detail::writeToYaml(tags_in_master_frame_, tag_size_map_, tag_bundle_name_, ofs);
     ros::shutdown();
   }
 }
 
-void TagBundleCalibrationNode::performCalibrationAndWriteToFile()
-{
-  std::ofstream ofs(config_file_path_);
-  apriltag_ros::generateTagBundleConfig(ofs, tag_buffer_map_, tag_bundle_name_, master_tag_id_);
-}
 } // namespace apriltag_ros

--- a/apriltag_ros/src/tag_bundle_calibration.cpp
+++ b/apriltag_ros/src/tag_bundle_calibration.cpp
@@ -1,0 +1,194 @@
+#include <apriltag_ros/tag_bundle_calibration.h>
+
+namespace apriltag_ros
+{
+void generateTagBundleConfig(
+    std::ostream& os,
+    const std::unordered_map<int, std::vector<AprilTagDetection>>& tag_buffer_map,
+    const std::string tag_bundle_name,
+    const int master_tag_id)
+{
+  if (tag_buffer_map.find(master_tag_id) == tag_buffer_map.end())
+  {
+    throw std::runtime_error("Master tag ID has not been observed");
+  }
+
+  // Calculating the average pose for each tag
+  std::unordered_map<int, geometry_msgs::Pose> average_pose_map;
+  std::unordered_map<int, double> tag_size_map;
+  for (const auto& [tag_id, detections] : tag_buffer_map)
+  {
+    // Extracting the poses from the detections
+    std::vector<geometry_msgs::Pose> poses;
+    poses.reserve(detections.size());
+    for (const auto& detection : detections)
+    {
+      // Ignore tag bundle detections in the tag bundle calibration routine
+      if (detection.id.size() > 1)
+        continue;
+      poses.push_back(detection.pose.pose.pose);
+    }
+
+    // Averaging the poses
+    average_pose_map[tag_id] = detail::averagePoses(poses);
+    tag_size_map[tag_id] = detections[0].size[0];
+  }
+
+  // Get the master tag's pose
+  const geometry_msgs::Pose& master_pose = average_pose_map[master_tag_id];
+
+  // Convert the master pose to a tf2::Transform
+  tf2::Transform master_tf;
+  tf2::fromMsg(master_pose, master_tf);
+
+  // Compute the tag poses in the frame of the master tag
+  std::unordered_map<int, geometry_msgs::Pose> tag_poses_in_master_frame;
+  tag_poses_in_master_frame[master_tag_id] = geometry_msgs::Pose();
+  for (const auto& [tag_id, pose] : average_pose_map)
+  {
+    if (tag_id == master_tag_id)
+      continue;
+
+    // Convert the tag pose to a tf2::Transform
+    tf2::Transform tag_tf;
+    tf2::fromMsg(pose, tag_tf);
+
+    // Calculate the transform from the master tag to the current tag
+    tf2::Transform transform_in_master_frame = master_tf.inverse() * tag_tf;
+
+    // Convert the transform back to a geometry_msgs::Pose and store it
+    tag_poses_in_master_frame[tag_id] = geometry_msgs::Pose();
+    tf2::toMsg(transform_in_master_frame, tag_poses_in_master_frame[tag_id]);
+  }
+
+  // Pass the tag map and the output stream to the writeToYaml function
+  detail::writeToYaml(tag_poses_in_master_frame, tag_size_map, tag_bundle_name, os);
+}
+
+namespace detail
+{
+geometry_msgs::Pose averagePoses(const std::vector<geometry_msgs::Pose>& poses)
+{
+  geometry_msgs::Pose ret;
+
+  if (poses.empty())
+    return ret;
+
+  // Averaging positions
+  double sz = static_cast<double>(poses.size());
+  geometry_msgs::Point init_position;
+  geometry_msgs::Point avg_position =
+      std::accumulate(poses.begin(),
+                      poses.end(),
+                      init_position,
+                      [sz](geometry_msgs::Point& accum, const geometry_msgs::Pose& curr)
+                      {
+                        accum.x += curr.position.x / sz;
+                        accum.y += curr.position.y / sz;
+                        accum.z += curr.position.z / sz;
+                        return accum;
+                      });
+
+  ret.position = avg_position;
+
+  // Averaging orientations
+  // https://math.stackexchange.com/questions/61146/averaging-quaternions/3435296#3435296
+  tf2::Quaternion init_quat{0.0, 0.0, 0.0, 0.0};
+  tf2::Quaternion first_quat, curr_quat;
+  tf2::fromMsg(poses[0].orientation, first_quat);
+
+  auto avg_quat_approx = std::accumulate(
+      poses.begin(),
+      poses.end(),
+      init_quat,
+      [&first_quat, &curr_quat](tf2::Quaternion& accum, const geometry_msgs::Pose& curr)
+      {
+        tf2::fromMsg(curr.orientation, curr_quat);
+        double weight = curr_quat.dot(first_quat) > 0.0 ? 1.0 : -1.0;
+        return accum + tf2::Quaternion(weight * curr_quat.x(),
+                                       weight * curr_quat.y(),
+                                       weight * curr_quat.z(),
+                                       weight * curr_quat.w());
+      });
+
+  ret.orientation = tf2::toMsg(avg_quat_approx.normalize());
+
+  return ret;
+}
+
+void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_in_master_frame,
+                 const std::unordered_map<int, double>& tag_size_map,
+                 const std::string& tag_bundle_name,
+                 std::ostream& os)
+{
+  os << "standalone_tags:\n";
+  os << "  [\n";
+  os << "  ]\n";
+  os << "tag_bundles:\n";
+  os << "  [\n";
+  os << "    {\n";
+  os << "      name: '" << tag_bundle_name << "',\n";
+  os << "      layout:\n";
+  os << "        [\n";
+
+  for (const auto& [tag_id, pose] : tag_poses_in_master_frame)
+  {
+    double size = tag_size_map.at(tag_id);
+    os << "          {id: " << tag_id << ", size: " << size << ", x: " << pose.position.x
+       << ", y: " << pose.position.y << ", z: " << pose.position.z << ", qw: " << pose.orientation.w
+       << ", qx: " << pose.orientation.x << ", qy: " << pose.orientation.y
+       << ", qz: " << pose.orientation.z << "},\n";
+  }
+
+  os << "        ]\n";
+  os << "    }\n";
+  os << "  ]\n";
+}
+
+} // namespace detail
+
+// TagBundleCalibrationNode class
+TagBundleCalibrationNode::TagBundleCalibrationNode(ros::NodeHandle& nh,
+                                                   int max_detections,
+                                                   const std::string& config_file_path,
+                                                   const std::string& tag_bundle_name,
+                                                   int master_tag_id) :
+    max_detections_(max_detections),
+    config_file_path_(config_file_path),
+    tag_bundle_name_(tag_bundle_name),
+    master_tag_id_(master_tag_id),
+    received_detections_(0)
+{
+  tag_detection_sub_ =
+      nh.subscribe("tag_detection", 1, &TagBundleCalibrationNode::tagDetectionCallback, this);
+}
+
+void TagBundleCalibrationNode::tagDetectionCallback(
+    const apriltag_ros::AprilTagDetectionArray::ConstPtr& msg)
+{
+  for (const auto& detection : msg->detections)
+  {
+    // Only standalone tags
+    if (detection.id.size() == 1)
+    {
+      if (tag_buffer_map_.find(detection.id[0]) == tag_buffer_map_.end())
+        tag_buffer_map_[detection.id[0]] = {};
+      tag_buffer_map_[detection.id[0]].push_back(detection);
+    }
+  }
+
+  received_detections_++;
+
+  if (received_detections_ >= max_detections_)
+  {
+    performCalibrationAndWriteToFile();
+    ros::shutdown();
+  }
+}
+
+void TagBundleCalibrationNode::performCalibrationAndWriteToFile()
+{
+  std::ofstream ofs(config_file_path_);
+  apriltag_ros::generateTagBundleConfig(ofs, tag_buffer_map_, tag_bundle_name_, master_tag_id_);
+}
+} // namespace apriltag_ros

--- a/apriltag_ros/src/tag_bundle_calibration.cpp
+++ b/apriltag_ros/src/tag_bundle_calibration.cpp
@@ -148,8 +148,7 @@ void writeToYaml(const std::unordered_map<int, geometry_msgs::Pose>& tag_poses_i
 } // namespace detail
 
 // TagBundleCalibrationNode class
-TagBundleCalibrationNode::TagBundleCalibrationNode(ros::NodeHandle& nh,
-                                                   int max_detections,
+TagBundleCalibrationNode::TagBundleCalibrationNode(int max_detections,
                                                    const std::string& config_file_path,
                                                    const std::string& tag_bundle_name,
                                                    int master_tag_id) :
@@ -159,8 +158,9 @@ TagBundleCalibrationNode::TagBundleCalibrationNode(ros::NodeHandle& nh,
     master_tag_id_(master_tag_id),
     received_detections_(0)
 {
+  ros::NodeHandle pnh{"~"};
   tag_detection_sub_ =
-      nh.subscribe("tag_detection", 1, &TagBundleCalibrationNode::tagDetectionCallback, this);
+      pnh.subscribe("tag_detections", 1, &TagBundleCalibrationNode::tagDetectionCallback, this);
 }
 
 void TagBundleCalibrationNode::tagDetectionCallback(


### PR DESCRIPTION
## Summary of Solution

Created a node called `apriltag_ros_tag_bundle_calibration_node` that consumes a remap-able `~tag_detections` feed until it reaches `max_detections`. You can set the master tag with param `master_tag_id`. It then averages the observed transforms to the master tag id over the duration of the observations and writes the generated config file to `config_file_path`. We average the transforms' quats using `tf2::Quaternion::slerp()` which seems to perform adequately.

## Open questions

- License headers on new files
- Unable to test against matlab script as ground truth (namely to compare `slerp()` to the home-brewed quat averaging solution)

## Successive Work

- I would like to modify the code to allow transform chaining, so that the master tag id doesn't always have to be in frame

## Demo
In the attached demo, we run a tag detector on a 3 x 3 tag grid with tag sizes 3cm and spacing between tags 4.5cm center to center along x and y. Camera is running at 15hz 720p rectified. 500 max detections. Would likely get better results at a higher resolution and higher max detections. This demo had largest errors on the z axis (max error was 7mm for tag 8) Whereas x and y errors were all sub mm. I will likely do some more testing with more detections and higher resolution (and flatter targets i.e not tags taped to the wall).

https://user-images.githubusercontent.com/109549970/233659739-910eac3a-6331-4358-84ad-fa4fce9d7612.mp4

