### PR TITLE
Add names to tag detections

### DIFF
--- a/apriltag_ros/msg/AprilTagDetection.msg
+++ b/apriltag_ros/msg/AprilTagDetection.msg
@@ -1,3 +1,6 @@
+# Tag/Tag Bundle name. Default names are tag_ID, where ID is the tag ID and bundle_I 
+# where I is the bundle index.
+string name
 # Tag ID(s). If a standalone tag, this is a vector of size 1. If a tag bundle,
 # this is a vector containing the IDs of each tag in the bundle.
 int32[] id

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -383,6 +383,7 @@ AprilTagDetectionArray TagDetector::detectTags (
 
       // Add the detection to the back of the tag detection array
       AprilTagDetection tag_detection;
+      tag_detection.name = bundleName;
       tag_detection.pose = bundle_pose;
       tag_detection.id = bundle.bundleIds();
       tag_detection.size = bundle.bundleSizes();

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -349,6 +349,7 @@ AprilTagDetectionArray TagDetector::detectTags (
 
     // Add the detection to the back of the tag detection array
     AprilTagDetection tag_detection;
+    tag_detection.name = standaloneDescription->frame_name();
     tag_detection.pose = tag_pose;
     tag_detection.id.push_back(detection->id);
     tag_detection.size.push_back(tag_size);


### PR DESCRIPTION
Can be useful for hashing tag bundles for consumers of a /tag_detection stream